### PR TITLE
Add introduction and goals section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,24 @@
 A rough draft of curriculum for a C Study Group, 2015.
 
  - [Curriculum][curriculum]
- - [How to Host This Event][how-to-host] **(TODO)**
  - [License][license]
 
+## Why Learn C?
+ - Learning new languages broadens your thinking
+ - Understanding low level programming
+ - Meet new people
+ - [By every measure of popularity][readwriteweb-language-popularity], C/C++/C#
+are in the top 5 most needed programming languages. There are plenty of
+opportunities to use C.
+ - Learning is fun.
+
+[readwriteweb-language-popularity]: http://readwrite.com/2012/06/05/5-ways-to-tell-which-programming-lanugages-are-most-popular
+
+## Goals
+ - Understand the topics listed in the [curriculum][curriculum].
+ - Complete a personal project written in C.
+ - Contribute to an open source project that is written in C.
+
 [curriculum]: ./curriculum.md
-[how-to-host]: #TODO
 [license]: ./MIT-LICENSE
+


### PR DESCRIPTION
A good syllabus has some kind of introduction and lists concrete goals.

Having goals for the group will help us and the attendees both assess
and improve at the end.

I added several inline 'TODO' items initially, but instead will be
adding them as issues:
 - TODO: add a 'How to Host This Event' link in the README, with
   instructions
 - TODO: Under 'Goals' in the README, link the personal project goal to
   a list of personal project ideas and completed work by attendees
 - TODO: Under 'Goals' in the README, link the open source contribution
   goal to a list of open source projects to contribute to.