### PR TITLE
Add more documentation and demos about compiling C programs

### DIFF
--- a/curriculum.md
+++ b/curriculum.md
@@ -1,7 +1,10 @@
 #C Programming Curriculum
 
 ## Week 1: Compilation
- - [Compiling and Running C Programs][compiling-and-running]
+ - Compiling and Running C Programs
+   - [gcc demo][gcc-demo]
+   - [clang demo][clang-demo]
+   - [clang versus gcc][clang-vs-gcc] from clang.llvm.org
  - [The "Main" Function][main]
    - **Exercise:** [Hello World][hello-world]
    - **Exercise:** [Fizz Buzz][fizz-buzz]
@@ -11,7 +14,9 @@
    - **Exercise:** [Fahrenheit to Celsius][k-r-p8] from The C Programming Language (p.
      8-14)
 
-[compiling-and-running]: notes/intro/compiling-and-running.md
+[gcc-demo]: notes/intro/gcc-demo.md
+[clang-demo]: notes/intro/clang-demo.md
+[clang-vs-gcc]: http://clang.llvm.org/comparison.html#gcc
 [main]: notes/intro/main_function.md
 [hello-world]: exercises/intro/hello_world.md
 [fizz-buzz]: exercises/intro/fizz_buzz.md

--- a/notes/intro/clang-demo.md
+++ b/notes/intro/clang-demo.md
@@ -1,0 +1,31 @@
+#Using Clang to Compile and Run C Programs
+
+To see all `clang` features:
+```
+clang --help
+```
+
+To compile with clang:
+```
+clang file_name.c -o executable_name
+```
+If you omit the `-o executable_name` the default executable name will be `a.out`.
+
+To run the program (in Mac):
+```
+./a.out
+```
+
+Try changing something in `file_name.c` and re-running `a.out`.
+
+Result? The output hasn't changed. You have to recompile and overwrite
+`a.out`.
+
+To compile and run in the same step:
+```
+clang file_name.c -o executable_name && ./executable_name
+```
+
+[Clang Documentation][clang-docs]
+
+[clang-docs]: http://clang.llvm.org/

--- a/notes/intro/gcc-demo.md
+++ b/notes/intro/gcc-demo.md
@@ -1,4 +1,9 @@
-#Compiling and Running C Programs
+#Using GCC to Compile and Run C Programs
+
+To see all `gcc` features:
+```
+gcc --help
+```
 
 To compile with gcc:
 ```
@@ -14,3 +19,8 @@ To do both in the same step:
 ```
 gcc file_name.c -o executable_name && ./executable_name
 ```
+
+
+[GCC Documentation][gcc-docs]
+
+[gcc-docs]: https://gcc.gnu.org/onlinedocs/


### PR DESCRIPTION
 - Adds notes on @hazmatzo's `clang` demo
 - Splits notes on `gcc` into separate document from `clang` example
 - Adds links to documentation for both `clang` and `gcc`
 - Adds link to comparison of `clang` and `gcc` in curriculum