### PR TITLE
remove asterisk in string literal example

### DIFF
--- a/notes/intro/strings.md
+++ b/notes/intro/strings.md
@@ -7,7 +7,7 @@ All strings in C are:
 
 ###String Literals
 ```C
-char *s = "string literal"
+char s = "string literal"
 ```
 
  * Immutable (can't be changed after assignment.)


### PR DESCRIPTION
@flarnie, I'm confused why there's an asterisk there.  Did you mean to declare `s` as a pointer? In which case, we still haven't officially introduced pointers at this stage.